### PR TITLE
add dropdown list for Typeof ticket, fixed typo

### DIFF
--- a/app/helpers/tickets_helper.rb
+++ b/app/helpers/tickets_helper.rb
@@ -1,4 +1,7 @@
 module TicketsHelper
+  # Defines all Ticket types to select from
+  @@ticket_types = ['Open Source', 'Competitive', 'ML', 'PClub Activities', 'Other']
+
   def status_word(status_bool)
     if status_bool
       "Approved"
@@ -13,5 +16,13 @@ module TicketsHelper
     else
       return ut.desc
     end
+  end
+
+  def get_ticket_types()
+    options = []
+    @@ticket_types.each do |ticket_type|
+      options.push([ticket_type, ticket_type])
+    end
+    return options
   end
 end

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -12,8 +12,10 @@
         <%= text_area_tag(:desc, params[:desc]) %>
         <%= label_tag(:points, "Points Requested [Enter 0 if unsure]") %>
         <%= number_field_tag(:points, params[:points], min: 0, step: 1) %>
-        <%= label_tag(:typeof, "Type of Request [Open Source, Competetive, ML, Other]") %>
-        <%= text_field_tag(:typeof, params[:typeof]) %>
+        <%= label_tag(:typeof, "Type of Request") %>
+        <%= select_tag(:typeof, options_for_select(
+            [['Open Source','Open Source'], ['Competitive', 'Competitive'],
+            ['ML', 'ML'], ['Other', 'Other']])) %>
         <%= submit_tag "Request" %>
     <% end %>
   </div>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -13,9 +13,7 @@
         <%= label_tag(:points, "Points Requested [Enter 0 if unsure]") %>
         <%= number_field_tag(:points, params[:points], min: 0, step: 1) %>
         <%= label_tag(:typeof, "Type of Request") %>
-        <%= select_tag(:typeof, options_for_select(
-            [['Open Source','Open Source'], ['Competitive', 'Competitive'],
-            ['ML', 'ML'], ['Other', 'Other']])) %>
+        <%= select_tag(:typeof, options_for_select(get_ticket_types())) %>
         <%= submit_tag "Request" %>
     <% end %>
   </div>


### PR DESCRIPTION
Adding text field dynamically for `Other` options needs CoffeeScript.
(I haven't seen how to do that 😛 ) 
Also would you like `:typeof` as 1, 2, 3, 4 for Open Source, Competitive, ML, Other respectively and use a helper function to render the string?